### PR TITLE
chore(deps): batch-bump GitHub Actions (consolidates dependabot #1-#5)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
           fetch-depth: 0
@@ -33,7 +33,7 @@ jobs:
         run: hugo --gc --minify --themesDir ../.. --printPathWarnings
 
       - name: Upload built site
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: exampleSite-public
           path: exampleSite/public

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,13 +18,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
           fetch-depth: 0
 
       - id: pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Setup Hugo Extended
         uses: peaceiris/actions-hugo@v3
@@ -42,7 +42,7 @@ jobs:
             --baseURL "${{ steps.pages.outputs.base_url }}/"
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: exampleSite/public
 
@@ -54,4 +54,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary

Consolidates dependabot PRs #1-#5 into one atomic change. All 5 touched the same 2 workflow files (\`build.yml\` + \`deploy.yml\`), so sequential merging would have caused 4 rebase rounds.

| Action | Old | New |
|---|---|---|
| \`actions/checkout\` | v4 | v6 |
| \`actions/configure-pages\` | v5 | v6 |
| \`actions/upload-artifact\` | v4 | v7 |
| \`actions/upload-pages-artifact\` | v3 | v5 |
| \`actions/deploy-pages\` | v4 | v5 |

Each individual bump was CI-green on its dependabot PR.

Closes #1, #2, #3, #4, #5.

## Test plan

- [x] Local edits verified via \`git diff\` — only version pins changed.
- [ ] CI build + deploy pass on this PR (the real test).