### PR TITLE
chore(release): cut v0.4.0 changelog section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ## [Unreleased]
 
+### Deferred to v0.5
+- **Auto-generated OG images** (#7) — moved again from v0.4 because no candidate path meets the ≤ 30 KB binary budget. Needs measured prototype before committing.
+- **Multi-section bio** (#9) — schema design call deferred per the issue's own "2026-Q3 candidate" recommendation.
+
+## [0.4.0] — 2026-05-10
+
+A11y, polish, and ergonomics release. All additions are strictly opt-in or transparent; v0.3 sites upgrade with no config edits. Closes #8, #10, #11; defers #7 + #9 to v0.5.
+
 ### Added
 - **Favicon polish** — opt-in `params.faviconSvg` and `params.appleTouchIcon` for SVG and iOS home-screen icons. Default behavior unchanged when unset.
 - **Demo-only gallery CSS** — `/themes/` and `/variants/` pages load a separate `static/css/gallery.css`; `static/css/bonsai.css` no longer ships gallery selectors to user sites. Saves ~1.9 KB raw / ~200 B gzipped on every real site. New `head_extra` block in `baseof.html` enables per-page stylesheet additions.
@@ -20,8 +28,9 @@ All notable changes to this project are documented here. Format follows [Keep a 
 ### Removed
 - Non-standard `data-theme="auto"` attribute from `<html>`. The CSS only ever queried `light` / `dark` via `:not([data-theme="..."])`; `auto` was a no-op. Inline FOUC script (v0.3) sets the attribute on first paint when the user has chosen, so behavior is unchanged.
 
-### Deferred
-- (v0.4 — auto-generated OG images, RSS opt-in, multi-section bio)
+### Deferred to v0.5
+- Auto-generated OG images (#7).
+- Multi-section bio (#9).
 
 ## [0.3.0] — 2026-05-03
 

--- a/plans/260510-0238-v0-4-release/phase-03-add-more-icons-10.md
+++ b/plans/260510-0238-v0-4-release/phase-03-add-more-icons-10.md
@@ -1,9 +1,9 @@
 ---
 phase: 3
-title: "Add more icons (#10)"
-status: pending
+title: Add more icons (#10)
+status: completed
 priority: P3
-effort: "30m"
+effort: 30m
 dependencies: []
 ---
 

--- a/plans/260510-0238-v0-4-release/phase-04-optional-rss-feed-8.md
+++ b/plans/260510-0238-v0-4-release/phase-04-optional-rss-feed-8.md
@@ -1,9 +1,9 @@
 ---
 phase: 4
-title: "Optional RSS feed (#8)"
-status: pending
+title: Optional RSS feed (#8)
+status: completed
 priority: P3
-effort: "45m"
+effort: 45m
 dependencies: []
 ---
 

--- a/plans/260510-0238-v0-4-release/phase-07-v0-4-0-release-prep.md
+++ b/plans/260510-0238-v0-4-release/phase-07-v0-4-0-release-prep.md
@@ -1,10 +1,13 @@
 ---
 phase: 7
-title: "v0.4.0 release prep"
-status: pending
+title: v0.4.0 release prep
+status: in-progress
 priority: P3
-effort: "30m"
-dependencies: [2, 3, 4]
+effort: 30m
+dependencies:
+  - 2
+  - 3
+  - 4
 ---
 
 # Phase 7: v0.4.0 release prep

--- a/plans/260510-0238-v0-4-release/plan.md
+++ b/plans/260510-0238-v0-4-release/plan.md
@@ -4,7 +4,7 @@ description: >-
   Ship issues #11, #10, #8 each as its own PR; tag v0.4.0. Issues #7 (OG
   auto-gen) and #9 (multi-section bio) deferred to v0.5 per their own deferral
   notes.
-status: pending
+status: in-progress
 priority: P2
 created: 2026-05-10T00:00:00.000Z
 ---
@@ -32,9 +32,9 @@ Each phase ships as its own feature branch + PR (matches repo pattern).
 | Phase | Name | Status |
 |-------|------|--------|
 | 2 | [Extract gallery CSS (#11)](./phase-02-extract-gallery-css-11.md) | Completed |
-| 3 | [Add more icons (#10)](./phase-03-add-more-icons-10.md) | Pending |
-| 4 | [Optional RSS feed (#8)](./phase-04-optional-rss-feed-8.md) | Pending |
-| 7 | [v0.4.0 release prep](./phase-07-v0-4-0-release-prep.md) | Pending |
+| 3 | [Add more icons (#10)](./phase-03-add-more-icons-10.md) | Completed |
+| 4 | [Optional RSS feed (#8)](./phase-04-optional-rss-feed-8.md) | Completed |
+| 7 | [v0.4.0 release prep](./phase-07-v0-4-0-release-prep.md) | In Progress |
 
 (Phase numbers preserved from original 7-phase scaffold for stable references.)
 


### PR DESCRIPTION
## Summary

Date the `Unreleased` v0.4 entries to `2026-05-10`. Reset `Unreleased` to list deferred-to-v0.5 items only (#7 OG auto-gen, #9 multi-section bio).

After this merges, `git tag v0.4.0` will be created locally and pushed.

## v0.4.0 ships
- **#11** Extract gallery CSS to demo-only stylesheet (PR #16)
- **#10** Vendor 10 more icons, 35 → 45 (PR #17)
- **#8** Optional RSS feed of `params.links` (PR #18)
- 17 a11y + polish findings from the 260510 audit (PR #15 — 10 inline + 7 follow-up)

## Deferred to v0.5
- **#7** Auto-generated OG images — no candidate path fits the ≤ 30 KB binary budget without measured prototype.
- **#9** Multi-section bio — schema design call deferred per the issue's own "2026-Q3 candidate" recommendation.

## Test plan
- [x] `hugo --gc --minify` clean
- [x] `bonsai.css` minified+gzipped under 3 KB (2,910 B)
- [x] `/index.xml` valid RSS 2.0 (Python ElementTree parse)
- [x] CHANGELOG dated to 2026-05-10
- [ ] Manual visual eyeball of all 4 palettes × 2 modes × 3 layouts before tag *(pending)*